### PR TITLE
[AC-1363] Add Forgot password verification code screen(UI only)

### DIFF
--- a/app/src/main/java/com/scalefocus/photopixels/navigation/NavDestinations.kt
+++ b/app/src/main/java/com/scalefocus/photopixels/navigation/NavDestinations.kt
@@ -10,6 +10,7 @@ import com.scalefocus.presentation.base.addNullableArguments
 import com.scalefocus.presentation.base.addNullableArgumentsLabels
 import com.scalefocus.presentation.screens.connect.ConnectServerScreen
 import com.scalefocus.presentation.screens.forgotpassword.mail.ForgotPasswordMailScreen
+import com.scalefocus.presentation.screens.forgotpassword.resset.ForgotPasswordCodeScreen
 import com.scalefocus.presentation.screens.login.LoginScreen
 import com.scalefocus.presentation.screens.register.RegisterScreen
 import com.scalefocus.presentation.screens.splash.SplashScreen
@@ -71,9 +72,18 @@ internal fun NavGraphBuilder.registerScreen(navController: NavHostController) {
     }
 }
 
-@Suppress("UnusedParameter")
 internal fun NavGraphBuilder.forgotPassScreenMail(navController: NavHostController) {
     composable(route = Screen.ForgotPasswordMail.route) {
-        ForgotPasswordMailScreen()
+        ForgotPasswordMailScreen(onNavigateToVerificationCodeScreen = {
+            navController.popBackStack()
+            navController.navigate(Screen.ForgotPasswordCode.route)
+        })
+    }
+}
+
+@Suppress("UnusedParameter")
+internal fun NavGraphBuilder.forgotPassCodeScreen(navController: NavHostController) {
+    composable(route = Screen.ForgotPasswordCode.route) {
+        ForgotPasswordCodeScreen()
     }
 }

--- a/app/src/main/java/com/scalefocus/photopixels/navigation/NavGraphs.kt
+++ b/app/src/main/java/com/scalefocus/photopixels/navigation/NavGraphs.kt
@@ -53,6 +53,7 @@ fun NavGraphs(navController: NavHostController, modifier: Modifier = Modifier) {
             loginScreen(navController)
             registerScreen(navController)
             forgotPassScreenMail(navController)
+            forgotPassCodeScreen(navController)
             homeScreenNavGraph(navController)
         }
     }

--- a/app/src/main/java/com/scalefocus/photopixels/navigation/Screen.kt
+++ b/app/src/main/java/com/scalefocus/photopixels/navigation/Screen.kt
@@ -10,6 +10,8 @@ sealed class Screen(val route: String) {
     data object Register : Screen("register")
 
     data object ForgotPasswordMail : Screen("forgot_pass_mail")
+
+    data object ForgotPasswordCode : Screen("forgot_pass_code")
 }
 
 sealed class HomeScreens(val route: String) {

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/mail/ForgotPasswordMailScreen.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/mail/ForgotPasswordMailScreen.kt
@@ -4,8 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+@Suppress("UnusedParameter")
 @Composable
-fun ForgotPasswordMailScreen(viewModel: ForgotPasswordMailViewModel = hiltViewModel()) {
+fun ForgotPasswordMailScreen(
+    onNavigateToVerificationCodeScreen: () -> Unit,
+    viewModel: ForgotPasswordMailViewModel = hiltViewModel()
+) {
     val state = viewModel.state.collectAsStateWithLifecycle().value
 
     ForgotPasswordMailContent(state, onSubmitActions = {

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeActions.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeActions.kt
@@ -1,0 +1,11 @@
+package com.scalefocus.presentation.screens.forgotpassword.resset
+
+sealed class ForgotPasswordCodeActions {
+    data class OnPasswordChange(val password: String) : ForgotPasswordCodeActions()
+
+    data class OnConfirmPasswordChange(val confirmPassword: String) : ForgotPasswordCodeActions()
+
+    data object OnSubmitClicked : ForgotPasswordCodeActions()
+
+    data object CloseErrorDialog : ForgotPasswordCodeActions()
+}

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeContent.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeContent.kt
@@ -1,0 +1,121 @@
+package com.scalefocus.presentation.screens.forgotpassword.resset
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.scalefocus.presentation.R
+import com.scalefocus.presentation.base.composeviews.CircularIndicator
+import com.scalefocus.presentation.base.composeviews.SFButton
+import com.scalefocus.presentation.base.composeviews.SFDefaultTextField
+import com.scalefocus.presentation.base.composeviews.SFPasswordTextField
+import com.scalefocus.presentation.base.composeviews.ShowAlertDialog
+import com.scalefocus.presentation.theme.PhotoPixelsTheme
+
+@Composable
+fun ForgotPasswordCodeContent(state: ForgotPasswordCodeState, onSubmitActions: (ForgotPasswordCodeActions) -> Unit) {
+    var verificationCode by remember { mutableStateOf("") }
+
+    if (state.isLoading) {
+        CircularIndicator()
+    }
+
+    state.errorMsgId?.let {
+        ShowAlertDialog(
+            title = stringResource(id = R.string.login_error_title),
+            negativeButtonText = null,
+            description = stringResource(id = it),
+            onPositiveClick = { onSubmitActions(ForgotPasswordCodeActions.CloseErrorDialog) }
+        )
+    }
+
+    Box {
+        Image(
+            modifier = Modifier.fillMaxSize(),
+            painter = painterResource(id = R.drawable.background),
+            alpha = 0.4f,
+            contentScale = ContentScale.Crop,
+            contentDescription = "background"
+        )
+
+        Box(contentAlignment = Alignment.Center) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 20.dp, end = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(Modifier.height(100.dp))
+                Image(painter = painterResource(id = R.drawable.logophotopixels2_light), contentDescription = "logo")
+
+                Spacer(Modifier.height(10.dp))
+
+                Text(text = stringResource(R.string.forgot_pass_code_msg).uppercase(), textAlign = TextAlign.Center)
+
+                Spacer(Modifier.height(5.dp))
+
+                SFDefaultTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = verificationCode,
+                    onValueChange = { verificationCode = it },
+                    label = stringResource(R.string.forgot_pass_ver_code)
+                )
+
+                SFPasswordTextField(
+                    password = state.password.value,
+                    label = stringResource(id = R.string.forgot_pass_new),
+                    onValueChange = {
+                        onSubmitActions(ForgotPasswordCodeActions.OnPasswordChange(it))
+                    }
+                )
+
+                SFPasswordTextField(
+                    password = state.confirmPassword.value,
+                    label = stringResource(
+                        id = R.string.forgot_pass_confirm
+                    ),
+                    onValueChange = {
+                        onSubmitActions(ForgotPasswordCodeActions.OnConfirmPasswordChange(it))
+                    }
+                )
+
+                Spacer(Modifier.height(30.dp))
+
+                val areFieldsEmpty = verificationCode.isEmpty() && state.password.value.isEmpty() &&
+                    state.confirmPassword.value.isEmpty()
+                SFButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { onSubmitActions(ForgotPasswordCodeActions.OnSubmitClicked) },
+                    enabled = !areFieldsEmpty,
+                    text = stringResource(id = R.string.button_submit)
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewContent() {
+    PhotoPixelsTheme {
+        ForgotPasswordCodeContent(state = ForgotPasswordCodeState(), onSubmitActions = {})
+    }
+}

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeScreen.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeScreen.kt
@@ -1,0 +1,14 @@
+package com.scalefocus.presentation.screens.forgotpassword.resset
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun ForgotPasswordCodeScreen(viewModel: ForgotPasswordCodeViewModel = hiltViewModel()) {
+    val state = viewModel.state.collectAsStateWithLifecycle().value
+
+    ForgotPasswordCodeContent(state = state, onSubmitActions = {
+        viewModel.submitAction(it)
+    })
+}

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeState.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeState.kt
@@ -1,0 +1,11 @@
+package com.scalefocus.presentation.screens.forgotpassword.resset
+
+import androidx.annotation.StringRes
+import com.scalefocus.presentation.base.textfield.SFTextEditField
+
+data class ForgotPasswordCodeState(
+    val password: SFTextEditField = SFTextEditField(value = ""),
+    val confirmPassword: SFTextEditField = SFTextEditField(value = ""),
+    val isLoading: Boolean = false,
+    @StringRes val errorMsgId: Int? = null
+)

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeViewModel.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/forgotpassword/resset/ForgotPasswordCodeViewModel.kt
@@ -1,0 +1,30 @@
+package com.scalefocus.presentation.screens.forgotpassword.resset
+
+import com.scalefocus.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ForgotPasswordCodeViewModel @Inject constructor() :
+    BaseViewModel<ForgotPasswordCodeState, ForgotPasswordCodeActions, Unit>(ForgotPasswordCodeState()) {
+
+        override suspend fun handleActions(action: ForgotPasswordCodeActions) {
+            when (action) {
+                ForgotPasswordCodeActions.OnSubmitClicked -> {
+                    // TODO: To be impl
+                }
+
+                ForgotPasswordCodeActions.CloseErrorDialog -> {
+                    // TODO: To be impl
+                }
+
+                is ForgotPasswordCodeActions.OnConfirmPasswordChange -> {
+                    // TODO: To be impl
+                }
+
+                is ForgotPasswordCodeActions.OnPasswordChange -> {
+                    // TODO: To be impl
+                }
+            }
+        }
+    }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -67,5 +67,10 @@
     <!-- Forgot password Screen -->
     <string name="forgot_pass_title">Forgot Password?</string>
     <string name="forgot_pass_screen_hint">Please enter your email address</string>
+    <string name="forgot_pass_code_msg">Please enter the verification code that was sent to your email address</string>
+    <string name="forgot_pass_ver_code">Verification code</string>
+    <string name="forgot_pass_code_hint">Code</string>
+    <string name="forgot_pass_new">New password</string>
+    <string name="forgot_pass_confirm">Confirm new password</string>
 
 </resources>


### PR DESCRIPTION
* Add Forgot password verification code screen(UI only)
Note: Business logic and network services will be implemented on different PR



<img width="330" height="630" alt="Screenshot 2024-05-30 at 16 21 18" src="https://github.com/scalefocus/photopixels-android/assets/170627175/3d520bce-e422-4065-898a-251c65042aa2">

