### PR TITLE
[AC-1367] Home/Register Screens improvements and bug fixes

### DIFF
--- a/app/src/main/java/com/scalefocus/photopixels/navigation/HomeScreenNavGraph.kt
+++ b/app/src/main/java/com/scalefocus/photopixels/navigation/HomeScreenNavGraph.kt
@@ -24,9 +24,6 @@ internal fun NavGraphBuilder.homeScreenNavGraph(navHostController: NavHostContro
 internal fun NavGraphBuilder.homeScreen(navHostController: NavHostController) {
     composable(route = HomeScreens.Home.route) {
         HomeScreen(
-            onNavigateToSettingsScreen = {
-                navHostController.navigate(HomeScreens.Settings.route)
-            },
             onNavigateToSyncScreen = {
                 // TODO: implement screens
             },

--- a/app/src/main/java/com/scalefocus/photopixels/navigation/NavGraphs.kt
+++ b/app/src/main/java/com/scalefocus/photopixels/navigation/NavGraphs.kt
@@ -2,7 +2,6 @@ package com.scalefocus.photopixels.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
@@ -68,12 +67,12 @@ private fun NavigationBar(navHostController: NavHostController) {
     NavigationBar {
         val navigationIcons = listOf(
             Icons.Default.Home,
-            Icons.Default.Check,
+            // Icons.Default.Check,
             Icons.Default.Settings
         )
         val labels = listOf(
             stringResource(R.string.home_screen_title),
-            stringResource(R.string.sync_screen_title),
+            // stringResource(R.string.sync_screen_title),
             stringResource(R.string.settings_screen_title)
         )
 
@@ -90,6 +89,7 @@ private fun NavigationBar(navHostController: NavHostController) {
                         }
 
                         HomeScreens.Sync.route -> {
+                            // TODO: Screen TBD
                         }
 
                         HomeScreens.Settings.route -> {

--- a/data/src/main/java/com/scalefocus/data/base/ApiHelper.kt
+++ b/data/src/main/java/com/scalefocus/data/base/ApiHelper.kt
@@ -63,6 +63,8 @@ private suspend fun translateServerError(httpResponse: HttpResponse): PhotoPixel
             var error: PhotoPixelError = PhotoPixelError.GenericError
             if (bodyText.contains(PhotoPixelsErrorResponses.INCORRECT_VERIFICATION_CODE)) {
                 error = PhotoPixelError.VerificationCodeIncorrect
+            } else if (bodyText.contains(PhotoPixelsErrorResponses.EMAIL_ALREADY_TAKEN)) {
+                error = PhotoPixelError.AccountAlreadyTaken
             }
             error
         }

--- a/data/src/main/java/com/scalefocus/data/base/PhotoPixelsErrorResponses.kt
+++ b/data/src/main/java/com/scalefocus/data/base/PhotoPixelsErrorResponses.kt
@@ -9,4 +9,5 @@ package com.scalefocus.data.base
  */
 internal object PhotoPixelsErrorResponses {
     const val INCORRECT_VERIFICATION_CODE = "The provided code is invalid"
+    const val EMAIL_ALREADY_TAKEN = "DuplicateUserName"
 }

--- a/data/src/main/java/com/scalefocus/data/repository/PhotosRepositoryImpl.kt
+++ b/data/src/main/java/com/scalefocus/data/repository/PhotosRepositoryImpl.kt
@@ -81,6 +81,10 @@ class PhotosRepositoryImpl @Inject constructor(
         return thumbnailsDao.getAllThumbnails().map { it.toDomain() }
     }
 
+    override suspend fun getThumbnailsFromDbCount(): Int {
+        return thumbnailsDao.getThumbnailsCount()
+    }
+
     override suspend fun clearThumbnailsTable() {
         thumbnailsDao.clearTable()
     }

--- a/data/src/main/java/com/scalefocus/data/storage/database/ThumbnailsDao.kt
+++ b/data/src/main/java/com/scalefocus/data/storage/database/ThumbnailsDao.kt
@@ -15,6 +15,9 @@ interface ThumbnailsDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertThumbnailPhotos(thumbnailsList: List<ThumbnailsEntity>)
 
+    @Query("Select count(*) from thumbnails_photos")
+    suspend fun getThumbnailsCount(): Int
+
     @Query("DELETE from thumbnails_photos")
     suspend fun clearTable()
 }

--- a/domain/src/main/java/com/scalefocus/domain/base/PhotoPixelError.kt
+++ b/domain/src/main/java/com/scalefocus/domain/base/PhotoPixelError.kt
@@ -12,4 +12,6 @@ sealed class PhotoPixelError {
     data object NoInternetConnection : PhotoPixelError()
 
     data object VerificationCodeIncorrect : PhotoPixelError()
+
+    data object AccountAlreadyTaken : PhotoPixelError()
 }

--- a/domain/src/main/java/com/scalefocus/domain/repository/PhotosRepository.kt
+++ b/domain/src/main/java/com/scalefocus/domain/repository/PhotosRepository.kt
@@ -40,5 +40,7 @@ interface PhotosRepository {
 
     suspend fun getThumbnailsFromDb(): List<PhotoUiData>
 
+    suspend fun getThumbnailsFromDbCount(): Int
+
     suspend fun clearThumbnailsTable()
 }

--- a/domain/src/main/java/com/scalefocus/domain/usecases/GetThumbnailsFromDbUseCase.kt
+++ b/domain/src/main/java/com/scalefocus/domain/usecases/GetThumbnailsFromDbUseCase.kt
@@ -8,4 +8,8 @@ class GetThumbnailsFromDbUseCase @Inject constructor(private val photosRepositor
     suspend fun invoke(): List<PhotoUiData> {
         return photosRepository.getThumbnailsFromDb()
     }
+
+    suspend fun getThumbnailsCount(): Int {
+        return photosRepository.getThumbnailsFromDbCount()
+    }
 }

--- a/presentation/src/main/java/com/scalefocus/presentation/base/composeviews/SFButton.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/base/composeviews/SFButton.kt
@@ -1,11 +1,14 @@
 package com.scalefocus.presentation.base.composeviews
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.scalefocus.presentation.theme.SFPrimaryDarkBlue
 
 @Composable
@@ -14,6 +17,7 @@ fun SFButton(
     onClick: () -> Unit,
     modifier: Modifier? = Modifier,
     color: Color? = SFPrimaryDarkBlue,
+    showLoader: Boolean? = false,
     enabled: Boolean = true
 ) {
     Button(
@@ -22,6 +26,13 @@ fun SFButton(
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(containerColor = color ?: SFPrimaryDarkBlue)
     ) {
-        Text(text = text)
+        if (showLoader == true) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                color = Color.White
+            )
+        } else {
+            Text(text = text)
+        }
     }
 }

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreen.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun HomeScreen(
     onNavigateToSyncScreen: () -> Unit,
-    onNavigateToSettingsScreen: () -> Unit,
     onNavigateToPreviewPhotosScreen: (String) -> Unit,
     viewModel: HomeScreenViewModel = hiltViewModel()
 ) {

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenActions.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenActions.kt
@@ -5,7 +5,7 @@ sealed class HomeScreenActions {
 
     data object CloseErrorDialog : HomeScreenActions()
 
-    data object OnGoToSyncButtonClick : HomeScreenActions()
+    data object OnSyncButtonClick : HomeScreenActions()
 
     data object StartSyncWorkers : HomeScreenActions()
 

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenContent.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenContent.kt
@@ -70,7 +70,10 @@ fun HomeScreenContent(state: HomeScreenState, onSubmitActions: (HomeScreenAction
         }
 
         if (state.photoThumbnails.isEmpty()) {
-            EmptyState(onBtnClick = { onSubmitActions(HomeScreenActions.OnGoToSyncButtonClick) })
+            EmptyState(
+                isSyncStarted = state.isSyncStarted,
+                onBtnClick = { onSubmitActions(HomeScreenActions.OnSyncButtonClick) }
+            )
         } else {
             ThumbnailsGrid(
                 state = state,
@@ -133,8 +136,8 @@ private fun ThumbnailImage(
 }
 
 @Composable
-private fun EmptyState(onBtnClick: () -> Unit) {
-    Column {
+private fun EmptyState(isSyncStarted: Boolean, onBtnClick: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
         val icon = painterResource(id = R.drawable.photo_library_24)
         Image(
             modifier = Modifier.size(100.dp),
@@ -155,8 +158,10 @@ private fun EmptyState(onBtnClick: () -> Unit) {
         Spacer(modifier = Modifier.height(30.dp))
 
         SFButton(
-            text = stringResource(R.string.home_screen_go_to_sync),
+            text = stringResource(R.string.button_sync_photos),
             color = SFSecondaryLightBlue,
+            enabled = !isSyncStarted,
+            showLoader = isSyncStarted,
             onClick = onBtnClick
         )
     }
@@ -179,7 +184,7 @@ private fun SmallGreenCircle(modifier: Modifier = Modifier) {
 @Preview(name = "EmptyState", group = "SingleViews", showBackground = true)
 private fun PreviewEmptyState() {
     PhotoPixelsTheme {
-        EmptyState(onBtnClick = {})
+        EmptyState(isSyncStarted = false, onBtnClick = {})
     }
 }
 

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenState.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/home/HomeScreenState.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.scalefocus.domain.model.PhotoUiData
 
 data class HomeScreenState(
+    val isSyncStarted: Boolean = false,
     val isLoading: Boolean = false,
     @StringRes val errorMsgId: Int? = null,
     val photoThumbnails: List<PhotoUiData> = emptyList()

--- a/presentation/src/main/java/com/scalefocus/presentation/screens/register/RegisterViewModel.kt
+++ b/presentation/src/main/java/com/scalefocus/presentation/screens/register/RegisterViewModel.kt
@@ -1,6 +1,7 @@
 package com.scalefocus.presentation.screens.register
 
 import androidx.lifecycle.viewModelScope
+import com.scalefocus.domain.base.PhotoPixelError
 import com.scalefocus.domain.base.Response
 import com.scalefocus.domain.usecases.ValidateFieldUseCase
 import com.scalefocus.domain.usecases.auth.RegisterUserUseCase
@@ -63,10 +64,16 @@ class RegisterViewModel @Inject constructor(
                     updateState { copy(isLoading = false) }
                     submitEvent(RegisterScreenEvents.NavigateToLoginScreen(email, password))
                 } else if (response is Response.Failure) {
+                    val errorMsgId: Int = if (response.error is PhotoPixelError.AccountAlreadyTaken) {
+                        R.string.register_account_taken_error
+                    } else {
+                        R.string.register_error_msg
+                    }
+
                     updateState {
                         copy(
                             isLoading = false,
-                            errorMsgId = R.string.register_error_msg
+                            errorMsgId = errorMsgId
                         )
                     }
                 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="register_pass_not_strong">Passwords must be at least 8 characters with at least one lowercase, one uppercase, and one non alphanumeric character.</string>
     <string name="register_name_incorrect">Please type correct name</string>
     <string name="register_email_incorrect">Please type correct email address</string>
+    <string name="register_account_taken_error">Account is already taken. Please choose different account.</string>
 
     <!-- Misc -->
     <string name="button_submit">Submit</string>
@@ -41,8 +42,8 @@
     <string name="home_screen_title">Home</string>
     <string name="sync_screen_title">Sync</string>
     <string name="settings_screen_title">Settings</string>
-    <string name="home_screen_empty_msg">Your Photo Pixels library is empty, go to sync screen to start uploading!</string>
-    <string name="home_screen_go_to_sync">Go to Sync screen</string>
+    <string name="home_screen_empty_msg">Your Photo Pixels library is empty.</string>
+    <string name="button_sync_photos">Sync photos</string>
     <string name="error_title">Error</string>
     <string name="error_permission_denied">Photos permissions are denied. Please provide PhotoPixels storage permissions.</string>
     <string name="error_generic">Something went wrong. Please try again later</string>


### PR DESCRIPTION
* Improve logic for showing Permissions Dialog at Home screen at first login or for new users
* Add Sync Button with Loading indicator at Home screen
* Remove Sync tab -> TBD if this screen is needed and what content should have
* Handle case with existing account upon Registration

![Screenshot_1717594896](https://github.com/scalefocus/photopixels-android/assets/170627175/09ea0a18-0389-445e-98bc-4287d81604a9)
![Screenshot_1717594892](https://github.com/scalefocus/photopixels-android/assets/170627175/a4cd238a-2520-4508-a375-29b6a0636630)
