### PR TITLE
Fix issue with older data showing on new user login

### DIFF
--- a/data/src/main/java/io/photopixels/data/di/NetworkModule.kt
+++ b/data/src/main/java/io/photopixels/data/di/NetworkModule.kt
@@ -134,16 +134,15 @@ class NetworkModule {
 
         install(Auth) {
             bearer {
-                val tokenPair = runBlocking {
-                    Pair(authDataStore.getAuthToken(), authDataStore.getRefreshToken())
-                }
-                val authToken = tokenPair.first
-                val refreshToken = tokenPair.second
-
-                authToken?.let {
-                    sendWithoutRequest { true } // Don't send token for token refresh request
-                    loadTokens {
-                        BearerTokens(it, refreshToken!!) // Use stored access token
+                sendWithoutRequest { true } // Don't send token for token refresh request
+                loadTokens {
+                    val tokenPair = Pair(authDataStore.getAuthToken(), authDataStore.getRefreshToken())
+                    val authToken = tokenPair.first
+                    val refreshToken = tokenPair.second
+                    authToken?.let {
+                        refreshToken?.let { refreshToken ->
+                            BearerTokens(authToken, refreshToken) // Use stored access token
+                        }
                     }
                 }
                 refreshTokens {
@@ -210,7 +209,7 @@ class NetworkModule {
         val newAuthToken = response.accessToken
         val newRefreshToken = response.refreshToken
 
-        Log.e("TAG", "Refresh token call succesfull!!!!")
+        Log.e("TAG", "Refresh token call successful!!!!")
         authDataStore.storeAuthHeaders(newAuthToken, newRefreshToken)
         Pair(newAuthToken, newRefreshToken)
     } catch (exception: ResponseException) {

--- a/data/src/main/java/io/photopixels/data/network/BackendApiImpl.kt
+++ b/data/src/main/java/io/photopixels/data/network/BackendApiImpl.kt
@@ -61,7 +61,7 @@ class BackendApiImpl @Inject constructor(
                     url("/api/user/login")
                     setBody(LoginRequest(email, password))
                 }.body<LoginResponse>()
-            clearBearerTokens()
+            clearBearerTokens() // Clear the old tokens, so the new ones can be loaded on the next request
             Response.Success(result)
         }
 

--- a/data/src/main/java/io/photopixels/data/network/BackendApiImpl.kt
+++ b/data/src/main/java/io/photopixels/data/network/BackendApiImpl.kt
@@ -61,7 +61,7 @@ class BackendApiImpl @Inject constructor(
                     url("/api/user/login")
                     setBody(LoginRequest(email, password))
                 }.body<LoginResponse>()
-
+            clearBearerTokens()
             Response.Success(result)
         }
 


### PR DESCRIPTION
Fixed the issue where after a logout and a new user login, the photos from the logged out user were shown. The problem was occurring because: 

1. After the logout the tokens were correctly cleared, but then the loadTokens block was called on the ConnectServerScreen, where we still don't have the Bearer token for the new user (loadTokens is called only on the first call after clearing the tokens).
2. The getAuthToken() and getRefreshToken() calls for getting the tokens from the DataStore were called outside of the loadTokens block, so they were called only the first time and not after every clear of the Bearer token.