### PR TITLE
Fix bottom navigation bar issues

### DIFF
--- a/app/src/main/java/io/photopixels/app/navigation/NavGraphs.kt
+++ b/app/src/main/java/io/photopixels/app/navigation/NavGraphs.kt
@@ -95,7 +95,7 @@ private fun NavigationBar(navHostController: NavHostController) {
                         // Pop up to the start destination of the graph to
                         // avoid building up a large stack of destinations
                         // on the back stack as users select items
-                        navHostController.graph.startDestinationRoute?.let { route ->
+                        navHostController.currentDestination?.parent?.startDestinationRoute?.let { route ->
                             popUpTo(route) {
                                 saveState = true
                             }


### PR DESCRIPTION
Fixed a bug where the popUpTo() was not working, because the selected route(Splash screen) was not in the stack, as it was already popped. This was causing 2 issues:

1. After each navigation to Home or Settings from the bottom bar, another copy of the screen was added to the back stack, so if you press back multiple times, you go thru all those copies before landing on the initial Home screen and closing the app on the next back.
2. The Home and Settings screens were recreated on every navigation, instead of saving and restoring the state.